### PR TITLE
Add icon to JupyterLab launcher

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@ node_modules/
 .ipynb_checkpoints
 .c9/
 *.lock
-#-lock.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,5 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 .c9/
--lock.json
 *.lock
+#-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,18 @@ RUN apt-get update && \
 RUN wget https://deb.nodesource.com/setup_8.x | sudo -E bash - && \
     sudo apt-get install -y nodejs npm
 
-# Set up plugin working directory
 USER jovyan
+
+# Set up common JupyterLab extensions
+RUN jupyter labextension install @jupyterlab/plotly-extension @jupyterlab/launcher-extension @jupyter-widgets/jupyterlab-manager @jupyterlab/hub-extension
+
+# Set up plugin working directory
 ENV SRCDIR="/home/jovyan/work/jupyterlab_cis"
 RUN mkdir -p $SRCDIR
 WORKDIR $SRCDIR
 
 # Install NPM dependencies
+RUN npm install -g typescript
 COPY package.json .
 RUN npm install
 
@@ -26,7 +31,6 @@ COPY style/* ./style/
 COPY tsconfig.json .
 
 # Perform TypeScript compile and install extension
-RUN npm install -g typescript
 RUN jupyter labextension install
 
 # Set up Cy-JupyterLab extension
@@ -34,10 +38,6 @@ RUN git clone https://github.com/idekerlab/cy-jupyterlab /home/jovyan/work/cy-ju
 WORKDIR /home/jovyan/work/cy-jupyterlab
 RUN git reset --hard cbb12372f9f108d2329a56aeac3d32aaf4440c33 && \
     jupyter labextension install
-
-# Set up Plotly JupyterLab extension
-RUN jupyter labextension install @jupyterlab/plotly-extension
-RUN jupyter labextension install @jupyter-widgets/jupyterlab-manager
 
 # Add documentation last
 COPY Dockerfile README.md ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,27 +4,49 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@jupyterlab/application": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-0.18.6.tgz",
+      "integrity": "sha512-tE+dGo3eGo4QYwax1UaprH1iso15m86DMJsQmP9sfXlpsrTxLJN+P7jPx/Nvy6MCSeVHy7uSN8+lu80QXSZsTA==",
+      "requires": {
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/docregistry": "^0.18.4",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/rendermime-interfaces": "^1.1.7",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/application": "^1.6.0",
+        "@phosphor/commands": "^1.5.0",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/properties": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0"
+      }
+    },
     "@jupyterlab/apputils": {
       "version": "0.18.4",
       "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.18.4.tgz",
       "integrity": "sha512-Nh+Xl6x29DGA0t1gND2vAtQ/ONATFjl/aoVSfgZ3grwuPGoSZvfUR3qAXKqlnqM0/QYtE98QX4GWYpcXohIbDw==",
       "requires": {
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/commands": "1.6.1",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/domutils": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/properties": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/virtualdom": "1.1.2",
-        "@phosphor/widgets": "1.6.0",
-        "@types/react": "16.0.41",
-        "react": "16.4.2",
-        "react-dom": "16.4.2",
-        "sanitize-html": "1.14.3"
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/commands": "^1.5.0",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/domutils": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/properties": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/virtualdom": "^1.1.2",
+        "@phosphor/widgets": "^1.6.0",
+        "@types/react": "~16.0.19",
+        "react": "~16.4.0",
+        "react-dom": "~16.4.0",
+        "sanitize-html": "~1.14.3"
       }
     },
     "@jupyterlab/attachments": {
@@ -32,12 +54,12 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-0.18.4.tgz",
       "integrity": "sha512-jvmtu2OM64eis1JJjnx7yuXWt2gdtaELnavtMeIlg5WVi0+XTI+ZaL9QlLvJBgEWH3tDbomgOBEqRqfwzz+M/g==",
       "requires": {
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/rendermime": "0.18.4",
-        "@jupyterlab/rendermime-interfaces": "1.1.7",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/signaling": "1.2.2"
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/rendermime-interfaces": "^1.1.7",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2"
       }
     },
     "@jupyterlab/cells": {
@@ -45,20 +67,20 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-0.18.4.tgz",
       "integrity": "sha512-RQYsp7Ot2cNs3uuSWOH6hb4g2e9GahMUcE26praQArvvHX17numMFk5wg/jehh+q+gk7qioSQTF0dZ0djwYwyw==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/attachments": "0.18.4",
-        "@jupyterlab/codeeditor": "0.18.4",
-        "@jupyterlab/codemirror": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/outputarea": "0.18.4",
-        "@jupyterlab/rendermime": "0.18.4",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/widgets": "1.6.0",
-        "react": "16.4.2"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/attachments": "^0.18.4",
+        "@jupyterlab/codeeditor": "^0.18.4",
+        "@jupyterlab/codemirror": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/outputarea": "^0.18.4",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0",
+        "react": "~16.4.0"
       }
     },
     "@jupyterlab/codeeditor": {
@@ -66,15 +88,15 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.18.4.tgz",
       "integrity": "sha512-FIekoRzFZN4ZPSQL/kGHg30cxHdna41pACYX6le6jSkm+2Ng5kOMaLrpSt7c/uj/qpdiRYIXs7Yy0eP+Cte/Lw==",
       "requires": {
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/widgets": "1.6.0",
-        "react": "16.4.2",
-        "react-dom": "16.4.2"
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0",
+        "react": "~16.4.0",
+        "react-dom": "~16.4.0"
       }
     },
     "@jupyterlab/codemirror": {
@@ -82,15 +104,15 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.18.4.tgz",
       "integrity": "sha512-77w/SehMOYTUy/IZDKayWwdl+YEjeEUzeqTVP7Ad7AJCAq4aFA8MS/RyVpHwY/JVriK+/kYnXsj/e4ocZ6rTIA==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/codeeditor": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "codemirror": "5.39.2"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/codeeditor": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "codemirror": "~5.39.0"
       }
     },
     "@jupyterlab/coreutils": {
@@ -98,16 +120,16 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.1.4.tgz",
       "integrity": "sha512-jSjn+xZj+kJrSWJ2Hz3jpxq0EXNpQrsnf+dD+pnDPc8mAeQ2XVu/x63VZyIDx8u2MELrIodFsUmQTxeudXKlOg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "ajv": "5.1.6",
-        "comment-json": "1.1.3",
-        "minimist": "1.2.0",
-        "moment": "2.21.0",
-        "path-posix": "1.0.0",
-        "url-parse": "1.4.3"
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "ajv": "~5.1.6",
+        "comment-json": "^1.1.3",
+        "minimist": "~1.2.0",
+        "moment": "~2.21.0",
+        "path-posix": "~1.0.0",
+        "url-parse": "~1.4.3"
       }
     },
     "@jupyterlab/docregistry": {
@@ -115,20 +137,20 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-0.18.4.tgz",
       "integrity": "sha512-1LmB9oA/0WJ0DP4etcfRnDzShKk5qyodF/csz/cr5z2a2rftLj0S3QCsUH1V5q66cuTec82UE2MQTTB2bmjTzg==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/codeeditor": "0.18.4",
-        "@jupyterlab/codemirror": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/rendermime": "0.18.4",
-        "@jupyterlab/rendermime-interfaces": "1.1.7",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/widgets": "1.6.0"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/codeeditor": "^0.18.4",
+        "@jupyterlab/codemirror": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/rendermime-interfaces": "^1.1.7",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0"
       }
     },
     "@jupyterlab/notebook": {
@@ -136,24 +158,24 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-0.18.5.tgz",
       "integrity": "sha512-ZfFav6M7OfBV8/BrcUxSb4OnP2xXaYYdBkwKv9NBnoQUpRWVCqjEi29/ZeXUEg1O5DckBNIgxLKySK65X2vsvw==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/cells": "0.18.4",
-        "@jupyterlab/codeeditor": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/docregistry": "0.18.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/rendermime": "0.18.4",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/domutils": "1.1.2",
-        "@phosphor/dragdrop": "1.3.0",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/properties": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/virtualdom": "1.1.2",
-        "@phosphor/widgets": "1.6.0",
-        "react": "16.4.2"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/cells": "^0.18.4",
+        "@jupyterlab/codeeditor": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/docregistry": "^0.18.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/domutils": "^1.1.2",
+        "@phosphor/dragdrop": "^1.3.0",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/properties": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/virtualdom": "^1.1.2",
+        "@phosphor/widgets": "^1.6.0",
+        "react": "~16.4.0"
       }
     },
     "@jupyterlab/observables": {
@@ -161,11 +183,11 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.7.tgz",
       "integrity": "sha512-EbmQH7+9SOBZXq3wOhBII7DQXeOeu7v5v8qPK7hJrjGUWSZhGYGglzm05ou5bP/Q2h+Y+Ar3tYX/LUupR6JuaA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2"
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2"
       }
     },
     "@jupyterlab/outputarea": {
@@ -173,18 +195,18 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-0.18.4.tgz",
       "integrity": "sha512-4/0zTvxhd9+NKsGm0BPcUhRUCEW77S3C9N7XvGjmHPRt55yjZgewiNWHGdxYDgXePiW4C3NJrYxfSm5UopTasQ==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/rendermime": "0.18.4",
-        "@jupyterlab/rendermime-interfaces": "1.1.7",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/widgets": "1.6.0"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/rendermime": "^0.18.4",
+        "@jupyterlab/rendermime-interfaces": "^1.1.7",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0"
       }
     },
     "@jupyterlab/rendermime": {
@@ -192,19 +214,19 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.18.4.tgz",
       "integrity": "sha512-0LXJMbNNwjju5zUV0tVSQ6aLxKZpLxJMlwzvEHbKB9/Fci7d8dNN9xja68p6ph7dVFwnX0tuv9eA0J1wehA3Gg==",
       "requires": {
-        "@jupyterlab/apputils": "0.18.4",
-        "@jupyterlab/codemirror": "0.18.4",
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@jupyterlab/rendermime-interfaces": "1.1.7",
-        "@jupyterlab/services": "3.1.4",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/widgets": "1.6.0",
-        "ansi_up": "3.0.0",
-        "marked": "0.4.0"
+        "@jupyterlab/apputils": "^0.18.4",
+        "@jupyterlab/codemirror": "^0.18.4",
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@jupyterlab/rendermime-interfaces": "^1.1.7",
+        "@jupyterlab/services": "^3.1.4",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0",
+        "ansi_up": "^3.0.0",
+        "marked": "~0.4.0"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
@@ -212,8 +234,8 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.1.7.tgz",
       "integrity": "sha512-ibDbZArLEOp9QXN7Un97MIbpa3y1gBH69ce6OuH//uD62enIwzTYEVNroQRG9gJ7wOcBScvy+rQuTqmm4yoGtw==",
       "requires": {
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/widgets": "1.6.0"
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/widgets": "^1.6.0"
       }
     },
     "@jupyterlab/services": {
@@ -221,14 +243,14 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.1.4.tgz",
       "integrity": "sha512-EK8WDbqGWsbsYAtd1AbpelaXOrtuHDgV5fNcdXTnHyhvA/uXn/yYRI+mKO2sTjVjAjVL6n/XNomd0czzp+kiGg==",
       "requires": {
-        "@jupyterlab/coreutils": "2.1.4",
-        "@jupyterlab/observables": "2.0.7",
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "node-fetch": "1.7.3",
-        "ws": "1.1.5"
+        "@jupyterlab/coreutils": "^2.1.4",
+        "@jupyterlab/observables": "^2.0.7",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "node-fetch": "~1.7.3",
+        "ws": "~1.1.4"
       }
     },
     "@phosphor/algorithm": {
@@ -236,12 +258,22 @@
       "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.2.tgz",
       "integrity": "sha1-/R3pEEyafzTpKGRYbd8ufy53eeg="
     },
+    "@phosphor/application": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@phosphor/application/-/application-1.6.0.tgz",
+      "integrity": "sha512-SeW2YFjtpmCYbZPpB4aTehyIsI/iGoSrV60Y4/OAp1CwDRT8eu1Rv276F67aermXQFjLK6c58JGucbhNq/BepQ==",
+      "requires": {
+        "@phosphor/commands": "^1.5.0",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/widgets": "^1.6.0"
+      }
+    },
     "@phosphor/collections": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
       "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
       "requires": {
-        "@phosphor/algorithm": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2"
       }
     },
     "@phosphor/commands": {
@@ -249,12 +281,12 @@
       "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.6.1.tgz",
       "integrity": "sha512-iRgn7QX64e0VwZ91KFo964a/LVpw9XtiYIYtpymEyKY757NXvx6ZZMt1CqKfntoDcSZJeVte4eV8jJWhZoVlDA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/domutils": "1.1.2",
-        "@phosphor/keyboard": "1.1.2",
-        "@phosphor/signaling": "1.2.2"
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/domutils": "^1.1.2",
+        "@phosphor/keyboard": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2"
       }
     },
     "@phosphor/coreutils": {
@@ -267,7 +299,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.2.tgz",
       "integrity": "sha1-oZLdai5sadXQnTns8zTauTd4Bg4=",
       "requires": {
-        "@phosphor/algorithm": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2"
       }
     },
     "@phosphor/domutils": {
@@ -280,8 +312,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.0.tgz",
       "integrity": "sha1-fOatOdbKIW1ipW94EE0Cp3rmcwc=",
       "requires": {
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2"
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2"
       }
     },
     "@phosphor/keyboard": {
@@ -294,8 +326,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
       "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/collections": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/collections": "^1.1.2"
       }
     },
     "@phosphor/properties": {
@@ -308,7 +340,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
       "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
       "requires": {
-        "@phosphor/algorithm": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2"
       }
     },
     "@phosphor/virtualdom": {
@@ -316,7 +348,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.2.tgz",
       "integrity": "sha1-zlXIbu8x5dDiax3JbqMr1oRFj0E=",
       "requires": {
-        "@phosphor/algorithm": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2"
       }
     },
     "@phosphor/widgets": {
@@ -324,17 +356,17 @@
       "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.6.0.tgz",
       "integrity": "sha512-HqVckVF8rJ15ss0Zf/q0AJ69ZKNFOO26qtNKAdGZ9SmmkSMf73X6pB0R3Fj5+Y4Sjl8ezIIKG6mXj+DxOofnwA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/commands": "1.6.1",
-        "@phosphor/coreutils": "1.3.0",
-        "@phosphor/disposable": "1.1.2",
-        "@phosphor/domutils": "1.1.2",
-        "@phosphor/dragdrop": "1.3.0",
-        "@phosphor/keyboard": "1.1.2",
-        "@phosphor/messaging": "1.2.2",
-        "@phosphor/properties": "1.1.2",
-        "@phosphor/signaling": "1.2.2",
-        "@phosphor/virtualdom": "1.1.2"
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/commands": "^1.5.0",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/domutils": "^1.1.2",
+        "@phosphor/dragdrop": "^1.3.0",
+        "@phosphor/keyboard": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/properties": "^1.1.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/virtualdom": "^1.1.2"
       }
     },
     "@types/react": {
@@ -347,9 +379,9 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
       "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
       "requires": {
-        "co": "4.6.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-schema-traverse": "^0.3.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ansi_up": {
@@ -361,6 +393,22 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -377,8 +425,14 @@
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
       "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
       "requires": {
-        "json-parser": "1.1.5"
+        "json-parser": "^1.0.0"
       }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "core-js": {
       "version": "1.2.7",
@@ -395,8 +449,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -416,7 +470,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -424,8 +478,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "encoding": {
@@ -433,7 +487,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "~0.4.13"
       }
     },
     "entities": {
@@ -451,13 +505,33 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.18"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "htmlparser2": {
@@ -465,12 +539,12 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "iconv-lite": {
@@ -478,7 +552,17 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -501,8 +585,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "3.0.0"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "js-tokens": {
@@ -515,7 +599,7 @@
       "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
       "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
       "requires": {
-        "esprima": "2.7.3"
+        "esprima": "^2.7.0"
       }
     },
     "json-schema-traverse": {
@@ -528,7 +612,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "jsonify": {
@@ -546,13 +630,22 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "marked": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
       "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -569,8 +662,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "object-assign": {
@@ -578,10 +671,25 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-posix": {
       "version": "1.0.0",
@@ -598,7 +706,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -606,8 +714,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "querystringify": {
@@ -620,10 +728,10 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
       "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-dom": {
@@ -631,10 +739,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.4.2.tgz",
       "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "requires": {
-        "fbjs": "0.8.17",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.2"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
       }
     },
     "readable-stream": {
@@ -642,19 +750,28 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -671,9 +788,9 @@
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.3.tgz",
       "integrity": "sha512-6tjiqhsgfQYNS+5B078RKDij7hSnQtNbWNQVJMjbCYT7XMtBeJLKrqbMT6+o2kva6SqMubcy/CS76/Bs6z49SQ==",
       "requires": {
-        "htmlparser2": "3.9.2",
-        "lodash.escaperegexp": "4.1.2",
-        "xtend": "4.0.1"
+        "htmlparser2": "^3.9.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "xtend": "^4.0.0"
       }
     },
     "setimmediate": {
@@ -686,8 +803,14 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.18",
@@ -704,8 +827,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
-        "querystringify": "2.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -718,13 +841,19 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
     "ws": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.18.0",
     "@jupyterlab/docregistry": "^0.18.4",
+    "@jupyterlab/launcher": "^0.18.4",
     "@jupyterlab/notebook": "^0.18.5"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import {
   ICommandPalette, InstanceTracker//, ToolbarButton
 } from '@jupyterlab/apputils';
 
+import { ILauncher } from '@jupyterlab/launcher';
+
 /*
 import {
   NotebookActions, NotebookPanel, INotebookModel
@@ -47,7 +49,7 @@ class CisWidget extends Widget {
     this.iframe.width = '100%';
     this.iframe.height = '100%';
     this.node.appendChild(this.iframe);
-    this.iframe.src = 'https://dev.cis-iu.ndslabs.org/#/';
+    this.iframe.src = 'https://dev.cis.ndslabs.org/#/';
   }
 
   // The iframe element associated with the widget.
@@ -58,7 +60,7 @@ class CisWidget extends Widget {
 };
 
 
-function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer) {
+function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer, launcher: ILauncher) {
   console.log('JupyterLab extension jupyterlab_cis is activated!');
 
   // Declare a widget variable
@@ -90,8 +92,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
       app.shell.activateById(widget.id);
     }
   });
-  
-    // Add an application command
+
+  // Add an application command
   /*app.commands.addCommand('cis:execute-graph-from-clipboard', {
     label: 'Execute Graph from Clipboard',
     execute: () => {
@@ -104,6 +106,17 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
   palette.addItem({ command: 'cis:open-model-composer', category: 'Crops in Silico' });
   //palette.addItem({ command: 'cis:execute-graph-from-clipboard', category: 'Crops in Silico' });
 
+  // Add a launcher item if the launcher is available
+  if (launcher) { 
+    launcher.add({ 
+      command: 'cis:open-model-composer', 
+      category: 'Crops in Silico', 
+      rank: 0 
+    }); 
+  } else {
+    console.log('No launcher found... skipping adding launcher icon');
+  }
+  
   // Track and restore the widget state
   let tracker = new InstanceTracker<Widget>({ namespace: 'cis' });
   restorer.restore(tracker, {
@@ -118,7 +131,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 const extension: JupyterLabPlugin<void> = {
   id: 'jupyterlab_cis',
   autoStart: true,
-  requires: [ICommandPalette, ILayoutRestorer],
+  requires: [ICommandPalette, ILayoutRestorer, ILauncher],
   activate: activate
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
   // Add an application command
   app.commands.addCommand('cis:open-model-composer', {
-    label: 'Show Model Composer',
+    label: 'Model Composer',
+    iconClass: 'jp-VegaIcon',
     execute: () => {
       if (!widget) {
         // Create a new widget if one does not exist
@@ -93,18 +94,8 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
     }
   });
 
-  // Add an application command
-  /*app.commands.addCommand('cis:execute-graph-from-clipboard', {
-    label: 'Execute Graph from Clipboard',
-    execute: () => {
-      let clipboardContents = "asdf"
-      console.log("Executing graph: ", clipboardContents);
-    }
-  });*/
-
   // Add commands to the palette.
   palette.addItem({ command: 'cis:open-model-composer', category: 'Crops in Silico' });
-  //palette.addItem({ command: 'cis:execute-graph-from-clipboard', category: 'Crops in Silico' });
 
   // Add a launcher item if the launcher is available
   if (launcher) { 


### PR DESCRIPTION
Changes:
* Added a "Graph" icon to JupyterLab's launcher to launch the Model Composer widget
* Reordered Dockerfile slightly to speed up the build - we now install official JupyterLab plugins before our own

How to Test:

This image has been built and pushed as `cropsinsilico/jupyterlab:latest`, so all JupyterLab instances on the current system should now have the launcher icon available once restarted.